### PR TITLE
Fix leak of ReplicaImp.m_appState

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -59,6 +59,8 @@ void computeBlockDigest(const uint64_t blockId,
 // It is used by the state transfer module.
 class IAppState {
  public:
+  virtual ~IAppState(){};
+
   // returns true IFF block blockId exists
   // (i.e. the block is stored in the application/storage layer).
   virtual bool hasBlock(uint64_t blockId) = 0;

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -265,7 +265,7 @@ class ReplicaImp : public IReplica,
   bftEngine::Replica *m_replicaPtr = nullptr;
   ICommandsHandler *m_cmdHandler = nullptr;
   bftEngine::IStateTransfer *m_stateTransfer = nullptr;
-  BlockchainAppState *m_appState = nullptr;
+  std::unique_ptr<BlockchainAppState> m_appState;
   concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
   ReplicaStateSyncImp m_replicaStateSync;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -194,6 +194,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
       m_lastBlock(dbAdapter->getLatestBlock()),
       m_ptrComm(comm),
       m_replicaConfig(replicaConfig),
+      m_appState(new BlockchainAppState(this)),
       aggregator_(aggregator) {
   bftEngine::SimpleBlockchainStateTransfer::Config state_transfer_config;
 
@@ -201,9 +202,8 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   state_transfer_config.cVal = m_replicaConfig.cVal;
   state_transfer_config.fVal = m_replicaConfig.fVal;
 
-  m_appState = new BlockchainAppState(this);
   m_stateTransfer = bftEngine::SimpleBlockchainStateTransfer::create(
-      state_transfer_config, m_appState, m_bcDbAdapter->getDb(), aggregator);
+      state_transfer_config, m_appState.get(), m_bcDbAdapter->getDb(), aggregator);
 }
 
 ReplicaImp::~ReplicaImp() {


### PR DESCRIPTION
Valgrind on concord turned up this warning:

==1== 267 (40 direct, 227 indirect) bytes in 1 blocks are definitely lost in loss record 438 of 976
==1==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1==    by 0x68B137: concord::consensus::ReplicaImp::ReplicaImp(concord::consensus::CommConfig&, concord::consensus::ReplicaConsensusConfig&, concord::storage::blockchain::DBAdapter*, concord::consensus::ReplicaStateSync&) (replica_imp.cpp:276)
==1==    by 0x483ED6: run_service(concord::config::ConcordConfiguration&, concord::config::ConcordConfiguration&, log4cplus::Logger&) (main.cpp:349)
==1==    by 0x48698D: main (main.cpp:547)

Once Toly's PR #276 merges, concord should use the ReplicaImp in this
repo, and not the duplicate in its own. So, the fix is submitted here.

The leak is fixed by making m_appState a unique_ptr so that we're sure
to release it when the ReplicaImp object is deleted.